### PR TITLE
OCaml 5.1 update: binary_string encoding

### DIFF
--- a/random3/random3.ml
+++ b/random3/random3.ml
@@ -30,6 +30,51 @@ module State = struct
     st1.idx <- st2.idx
 
 
+  let serialization_prefix =
+    "lfsr1:"
+    (* "lfsr" denotes the algorithm currently in use, and '1' is
+       a version number. Each Random algorithm or serialization format
+       should have distinct prefix , so that users get a clean error
+       instead of believing that they faithfully reproduce their
+       previous state and in fact get a differrent stream.
+
+       Note that there is no constraint to keep the same
+       "<name><ver>:<data>" format or message size in future versions,
+       we could change the format completely if we wanted as long
+       as there is no confusion possible with the previous formats. *)
+
+  let serialization_prefix_len =
+    String.length serialization_prefix
+
+  let to_binary_string s =
+    let prefix = serialization_prefix in
+    let preflen = serialization_prefix_len in
+    let buf = Bytes.create (preflen + 55 * 4 + 1) in
+    Bytes.blit_string prefix 0 buf 0 preflen;
+    for i = 0 to 54 do
+      Bytes.set_int32_le buf (preflen + i * 4)
+        (Int32.of_int (s.st.(i) land 0x3FFFFFFF))
+    done;
+    Bytes.set_int8 buf (preflen + 55 * 4) s.idx;
+    Bytes.unsafe_to_string buf
+
+  let of_binary_string buf =
+    let prefix = serialization_prefix in
+    let preflen = serialization_prefix_len in
+    if String.length buf <> preflen + 1 + 55 * 4
+       || not (String.starts_with ~prefix buf)
+    then
+      failwith
+        ("Random3.State.of_binary_string: expected a format \
+          compatible with Random3 PRNG");
+    let st = new_state () in
+    for i=0 to 54 do
+      let n = String.get_int32_le buf (preflen + i * 4) in
+      st.st.(i) <- Int32.(to_int @@ logand n 0x3FFFFFFFl)
+    done;
+    st.idx <- String.get_int8 buf (preflen + 55 * 4);
+    st
+
   let full_init s seed =
     let combine accu x = Digest.string (accu ^ Int.to_string x) in
     let extract d =

--- a/random3/random3.mli
+++ b/random3/random3.mli
@@ -124,6 +124,39 @@ module State : sig
   (** These functions are the same as the basic functions, except that they
       use (and update) the given PRNG state instead of the default one.
   *)
+
+
+  val to_binary_string : t -> string
+  (** Serializes the PRNG state into an immutable sequence of bytes.
+      See {!of_binary_string} for deserialization.
+
+      The [string] type is intended here for serialization only, the
+      encoding is not human-readable and may not be printable.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      @since 5.1
+  *)
+
+  val of_binary_string : string -> t
+  (** Deserializes a byte sequence obtained by calling
+      {!to_binary_string}. The resulting PRNG state will produce the
+      same random numbers as the state that was passed as input to
+      {!to_binary_string}.
+
+      @raise Failure if the input is not in the expected format.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      Unlike the functions provided by the {!Marshal} module, this
+      function either produces a valid state or fails cleanly with
+      a [Failure] exception. It can be safely used on user-provided,
+      untrusted inputs.
+
+      @since 5.1
+  *)
 end
 
 

--- a/random4/random4.mli
+++ b/random4/random4.mli
@@ -124,6 +124,40 @@ module State : sig
   (** These functions are the same as the basic functions, except that they
       use (and update) the given PRNG state instead of the default one.
   *)
+
+
+  val to_binary_string : t -> string
+  (** Serializes the PRNG state into an immutable sequence of bytes.
+      See {!of_binary_string} for deserialization.
+
+      The [string] type is intended here for serialization only, the
+      encoding is not human-readable and may not be printable.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      @since 5.1
+  *)
+
+  val of_binary_string : string -> t
+  (** Deserializes a byte sequence obtained by calling
+      {!to_binary_string}. The resulting PRNG state will produce the
+      same random numbers as the state that was passed as input to
+      {!to_binary_string}.
+
+      @raise Failure if the input is not in the expected format.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      Unlike the functions provided by the {!Marshal} module, this
+      function either produces a valid state or fails cleanly with
+      a [Failure] exception. It can be safely used on user-provided,
+      untrusted inputs.
+
+      @since 5.1
+  *)
+
 end
 
 

--- a/random5/random5.mli
+++ b/random5/random5.mli
@@ -145,6 +145,38 @@ module State : sig
       correlation.  Both PRNGs can be split later, arbitrarily many times.
    *)
 
+  val to_binary_string : t -> string
+  (** Serializes the PRNG state into an immutable sequence of bytes.
+      See {!of_binary_string} for deserialization.
+
+      The [string] type is intended here for serialization only, the
+      encoding is not human-readable and may not be printable.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      @since 5.1
+  *)
+
+  val of_binary_string : string -> t
+  (** Deserializes a byte sequence obtained by calling
+      {!to_binary_string}. The resulting PRNG state will produce the
+      same random numbers as the state that was passed as input to
+      {!to_binary_string}.
+
+      @raise Failure if the input is not in the expected format.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      Unlike the functions provided by the {!Marshal} module, this
+      function either produces a valid state or fails cleanly with
+      a [Failure] exception. It can be safely used on user-provided,
+      untrusted inputs.
+
+      @since 5.1
+  *)
+
 end
 
 val get_state : unit -> State.t

--- a/random5o/random5o.ml
+++ b/random5o/random5o.ml
@@ -39,6 +39,50 @@ module State = struct
     let s = create () in
     set s i1 i2 i3 i4; s
 
+
+  let serialization_prefix =
+    "lxm1:"
+    (* "lxm" denotes the algorithm currently in use, and '1' is
+       a version number. We should update this prefix if we change
+       the Random algorithm or the serialization format, so that users
+       get a clean error instead of believing that they faithfully
+       reproduce their previous state and in fact get a differrent
+       stream.
+
+       Note that there is no constraint to keep the same
+       "<name><ver>:<data>" format or message size in future versions,
+       we could change the format completely if we wanted as long
+       as there is no confusion possible with the previous formats. *)
+
+  let serialization_prefix_len =
+    String.length serialization_prefix
+
+  let to_binary_string s =
+    let prefix = serialization_prefix in
+    let preflen = serialization_prefix_len in
+    let buf = Bytes.create (preflen + 4 * 8) in
+    Bytes.blit_string prefix 0 buf 0 preflen;
+    for i = 0 to 3 do
+      Bytes.set_int64_le buf (preflen + i * 8) (Array1.get s i)
+    done;
+    Bytes.unsafe_to_string buf
+
+  let of_binary_string buf =
+    let prefix = serialization_prefix in
+    let preflen = serialization_prefix_len in
+    if String.length buf <> preflen + 4 * 8
+       || not (String.starts_with ~prefix buf)
+    then
+      failwith
+        ("Random.State.of_binary_string: expected a format \
+          compatible with OCaml " ^ Sys.ocaml_version);
+    let i1 = String.get_int64_le buf (preflen + 0 * 8) in
+    let i2 = String.get_int64_le buf (preflen + 1 * 8) in
+    let i3 = String.get_int64_le buf (preflen + 2 * 8) in
+    let i4 = String.get_int64_le buf (preflen + 3 * 8) in
+    mk i1 i2 i3 i4
+
+
   let assign (dst: t) (src: t) =
     Array1.blit src dst
 

--- a/random5o/random5o.mli
+++ b/random5o/random5o.mli
@@ -145,6 +145,38 @@ module State : sig
       correlation.  Both PRNGs can be split later, arbitrarily many times.
    *)
 
+  val to_binary_string : t -> string
+  (** Serializes the PRNG state into an immutable sequence of bytes.
+      See {!of_binary_string} for deserialization.
+
+      The [string] type is intended here for serialization only, the
+      encoding is not human-readable and may not be printable.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      @since 5.1
+  *)
+
+  val of_binary_string : string -> t
+  (** Deserializes a byte sequence obtained by calling
+      {!to_binary_string}. The resulting PRNG state will produce the
+      same random numbers as the state that was passed as input to
+      {!to_binary_string}.
+
+      @raise Failure if the input is not in the expected format.
+
+      Note that the serialization format may differ across OCaml
+      versions.
+
+      Unlike the functions provided by the {!Marshal} module, this
+      function either produces a valid state or fails cleanly with
+      a [Failure] exception. It can be safely used on user-provided,
+      untrusted inputs.
+
+      @since 5.1
+  *)
+
 end
 
 val get_state : unit -> State.t

--- a/tests/binary_string_roundtrip.ml
+++ b/tests/binary_string_roundtrip.ml
@@ -1,0 +1,27 @@
+module type state = sig
+  type t
+  val to_binary_string : t -> string
+  val of_binary_string : string -> t
+end
+
+module type random = sig
+  module State: state
+  val init: int -> unit
+  val get_state: unit -> State.t
+end
+
+let test name (module R: random) =
+  let init n = R.init n; R.get_state () in
+
+  let roundtrip seed =
+    let s = init seed in
+    s = R.State.(of_binary_string @@ to_binary_string s)
+  in
+  if not @@ List.for_all roundtrip (List.init 100 Fun.id) then
+    failwith (Format.asprintf "Roundtrip failed for %s generator" name)
+
+let () =
+  test "random3" (module Random3);
+  test "random4" (module Random4);
+  test "random5" (module Random5);
+  test "random5o" (module Random5o)

--- a/tests/consistency.ml
+++ b/tests/consistency.ml
@@ -25,8 +25,8 @@ module R3_equal_R4:sig module type t = r3 end = struct
   module type t = r4
 end
 
-#if OCAML_VERSION > (5,0,0)
+#if OCAML_VERSION >= (5,1,0)
 module R5_equal_Stdlib: sig module type t = r5 end = struct
-  module type t = module type of Random
+  module type t = module type of Stdlib__Random
 end
 #endif

--- a/tests/dune
+++ b/tests/dune
@@ -16,6 +16,13 @@
  (modules Random5_test)
 )
 
+(tests
+ (names binary_string_roundtrip)
+ (modules binary_string_roundtrip)
+ (libraries random3 random4 random5 random5o)
+)
+
+
 (test
  (name consistency)
  (libraries random3 random4 random5 random5o)


### PR DESCRIPTION
This is a planned update for OCaml 5.1 which adds the `to_binary_string` and `of_binary_string` functions to all PRNGs.